### PR TITLE
Adopt MCP attribute-based tooling in .NET server

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,3 +801,34 @@ http.createServer(async (req, res) => {
 
 
 <!--- End of tools generated section -->
+
+#### C# MCP server tools
+
+The .NET implementation bundled in `dotnet/PlaywrightMcpServer` exposes the following tools. Unless noted otherwise the tools do not currently accept arguments and surface a placeholder response until their behavior is implemented.
+
+- **browser_navigate** — Navigate the active page to a specific URL. Parameters: `url` (string, required).
+- **browser_click** — Click an element by CSS/XPath/text selector. Parameters: `selector` (string, required; CSS by default, prefix with `xpath=` for XPath, `text=` for text).
+- **browser_navigate_back** — Navigate to the previous page in the browser history.
+- **browser_console_messages** — Inspect console output.
+- **browser_drag** — Drag an element on the page.
+- **browser_evaluate** — Evaluate JavaScript in the page.
+- **browser_file_upload** — Upload a file to an input.
+- **browser_fill_form** — Fill a form field.
+- **browser_handle_dialog** — Handle browser dialogs.
+- **browser_hover** — Hover an element.
+- **browser_select_option** — Select option in a form control.
+- **browser_type** — Type into an element.
+- **browser_close** — Close the current tab.
+- **browser_install** — Install additional browser binaries.
+- **browser_network_requests** — Inspect network requests.
+- **browser_press_key** — Press a key in the page.
+- **browser_resize** — Resize the page viewport.
+- **browser_snapshot** — Capture a DOM snapshot.
+- **browser_tabs** — List open tabs.
+- **browser_take_screenshot** — Capture a screenshot.
+- **browser_wait_for** — Wait for a condition.
+- **browser_connect** — Connect to an existing browser (available when the server is launched with `--connect-tool`).
+- **browser_pdf_save** — Save the current page as PDF (requires the `pdf` capability).
+- **browser_mouse_move_xy** — Move the mouse using coordinates (requires the `vision` capability).
+- **browser_mouse_click_xy** — Click using page coordinates (requires the `vision` capability).
+- **browser_mouse_drag_xy** — Drag using page coordinates (requires the `vision` capability).

--- a/dotnet/PlaywrightMcpServer/BrowserTools.cs
+++ b/dotnet/PlaywrightMcpServer/BrowserTools.cs
@@ -1,0 +1,176 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using ModelContextProtocol.Server;
+using PlaywrightMcpServer.Browser;
+
+namespace PlaywrightMcpServer;
+
+internal sealed class BrowserTools
+{
+    private readonly BrowserManager _browserManager;
+
+    public BrowserTools(BrowserManager browserManager)
+    {
+        _browserManager = browserManager;
+    }
+
+    [McpServerTool("browser_navigate", "Navigate to a URL")]
+    [Description("Navigate the active page to a specific URL.")]
+    [McpServerToolType(ToolType.Destructive)]
+    public async Task<McpResponse> NavigateAsync(NavigateArguments arguments, CancellationToken cancellationToken)
+    {
+        await _browserManager.NavigateAsync(arguments.Url, cancellationToken);
+        var snapshot = await _browserManager.CaptureSnapshotAsync(cancellationToken);
+        var code = $"await page.goto('{ResponseBuilder.EscapeJavaScript(arguments.Url)}');";
+        return ResponseBuilder.Success(code, snapshot);
+    }
+
+    [McpServerTool("browser_navigate_back", "Go back")]
+    [Description("Navigate to the previous page in the browser history.")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> NavigateBackAsync()
+        => NotImplementedAsync("browser_navigate_back");
+
+    [McpServerTool("browser_click", "Click element")]
+    [Description("Click an element by CSS/XPath/text selector.")]
+    [McpServerToolType(ToolType.Destructive)]
+    public async Task<McpResponse> ClickAsync(ClickArguments arguments, CancellationToken cancellationToken)
+    {
+        var code = await _browserManager.ClickAsync(arguments.Selector, cancellationToken);
+        var snapshot = await _browserManager.CaptureSnapshotAsync(cancellationToken);
+        return ResponseBuilder.Success(code, snapshot);
+    }
+
+    [McpServerTool("browser_console_messages", "Read console messages")]
+    [Description("Inspect console output")]
+    [McpServerToolType(ToolType.ReadOnly)]
+    public Task<McpResponse> ReadConsoleMessagesAsync() => NotImplementedAsync("browser_console_messages");
+
+    [McpServerTool("browser_drag", "Drag element")]
+    [Description("Drag an element on the page")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> DragAsync() => NotImplementedAsync("browser_drag");
+
+    [McpServerTool("browser_evaluate", "Evaluate script")]
+    [Description("Evaluate JavaScript in the page")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> EvaluateAsync() => NotImplementedAsync("browser_evaluate");
+
+    [McpServerTool("browser_file_upload", "Upload file")]
+    [Description("Upload a file to an input")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> UploadFileAsync() => NotImplementedAsync("browser_file_upload");
+
+    [McpServerTool("browser_fill_form", "Fill form")]
+    [Description("Fill a form field")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> FillFormAsync() => NotImplementedAsync("browser_fill_form");
+
+    [McpServerTool("browser_handle_dialog", "Handle dialog")]
+    [Description("Handle browser dialogs")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> HandleDialogAsync() => NotImplementedAsync("browser_handle_dialog");
+
+    [McpServerTool("browser_hover", "Hover element")]
+    [Description("Hover an element")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> HoverAsync() => NotImplementedAsync("browser_hover");
+
+    [McpServerTool("browser_select_option", "Select option")]
+    [Description("Select option in a form control")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> SelectOptionAsync() => NotImplementedAsync("browser_select_option");
+
+    [McpServerTool("browser_type", "Type text")]
+    [Description("Type into an element")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> TypeAsync() => NotImplementedAsync("browser_type");
+
+    [McpServerTool("browser_close", "Close tab")]
+    [Description("Close the current tab")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> CloseAsync() => NotImplementedAsync("browser_close");
+
+    [McpServerTool("browser_install", "Install browser")]
+    [Description("Install additional browser binaries")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> InstallAsync() => NotImplementedAsync("browser_install");
+
+    [McpServerTool("browser_network_requests", "Inspect network")]
+    [Description("Inspect network requests")]
+    [McpServerToolType(ToolType.ReadOnly)]
+    public Task<McpResponse> NetworkRequestsAsync() => NotImplementedAsync("browser_network_requests");
+
+    [McpServerTool("browser_press_key", "Press key")]
+    [Description("Press a key in the page")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> PressKeyAsync() => NotImplementedAsync("browser_press_key");
+
+    [McpServerTool("browser_resize", "Resize page")]
+    [Description("Resize the page viewport")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> ResizeAsync() => NotImplementedAsync("browser_resize");
+
+    [McpServerTool("browser_snapshot", "Take snapshot")]
+    [Description("Capture a DOM snapshot")]
+    [McpServerToolType(ToolType.ReadOnly)]
+    public Task<McpResponse> SnapshotAsync() => NotImplementedAsync("browser_snapshot");
+
+    [McpServerTool("browser_tabs", "List tabs")]
+    [Description("List open tabs")]
+    [McpServerToolType(ToolType.ReadOnly)]
+    public Task<McpResponse> TabsAsync() => NotImplementedAsync("browser_tabs");
+
+    [McpServerTool("browser_take_screenshot", "Screenshot")]
+    [Description("Capture a screenshot")]
+    [McpServerToolType(ToolType.ReadOnly)]
+    public Task<McpResponse> ScreenshotAsync() => NotImplementedAsync("browser_take_screenshot");
+
+    [McpServerTool("browser_wait_for", "Wait for")]
+    [Description("Wait for a condition")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> WaitForAsync() => NotImplementedAsync("browser_wait_for");
+
+    [McpServerTool("browser_connect", "Connect to browser", RequiresConnectTool = true)]
+    [Description("Connect to an existing browser")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> ConnectAsync() => NotImplementedAsync("browser_connect");
+
+    [McpServerTool("browser_pdf_save", "Save PDF", Capability = "pdf")]
+    [Description("Save the current page as PDF")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> SavePdfAsync() => NotImplementedAsync("browser_pdf_save");
+
+    [McpServerTool("browser_mouse_move_xy", "Move mouse", Capability = "vision")]
+    [Description("Move the mouse using coordinates")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> MoveMouseAsync() => NotImplementedAsync("browser_mouse_move_xy");
+
+    [McpServerTool("browser_mouse_click_xy", "Click mouse", Capability = "vision")]
+    [Description("Click using page coordinates")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> MouseClickAsync() => NotImplementedAsync("browser_mouse_click_xy");
+
+    [McpServerTool("browser_mouse_drag_xy", "Drag mouse", Capability = "vision")]
+    [Description("Drag using page coordinates")]
+    [McpServerToolType(ToolType.Destructive)]
+    public Task<McpResponse> MouseDragAsync() => NotImplementedAsync("browser_mouse_drag_xy");
+
+    private static Task<McpResponse> NotImplementedAsync(string name)
+    {
+        return Task.FromResult(ResponseBuilder.Error($"Tool \"{name}\" is not implemented in the C# server."));
+    }
+
+    internal sealed record NavigateArguments(
+        [property: Required]
+        [property: Description("The URL to navigate to.")]
+        string Url
+    );
+
+    internal sealed record ClickArguments(
+        [property: Required]
+        [property: Description("Selector (CSS default; prefix with xpath= for XPath, text= for text)")]
+        string Selector
+    );
+}

--- a/dotnet/PlaywrightMcpServer/ModelContextProtocol/Server/McpAttributes.cs
+++ b/dotnet/PlaywrightMcpServer/ModelContextProtocol/Server/McpAttributes.cs
@@ -1,0 +1,32 @@
+using PlaywrightMcpServer;
+
+namespace ModelContextProtocol.Server;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class McpServerToolAttribute : Attribute
+{
+    public McpServerToolAttribute(string name, string title)
+    {
+        Name = name;
+        Title = title;
+    }
+
+    public string Name { get; }
+
+    public string Title { get; }
+
+    public string Capability { get; set; } = "core";
+
+    public bool RequiresConnectTool { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class McpServerToolTypeAttribute : Attribute
+{
+    public McpServerToolTypeAttribute(ToolType type)
+    {
+        Type = type;
+    }
+
+    public ToolType Type { get; }
+}

--- a/dotnet/PlaywrightMcpServer/ToolRegistry.cs
+++ b/dotnet/PlaywrightMcpServer/ToolRegistry.cs
@@ -1,81 +1,53 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using ModelContextProtocol.Server;
 using PlaywrightMcpServer.Browser;
 
 namespace PlaywrightMcpServer;
 
 internal sealed class ToolRegistry
 {
-    private readonly BrowserManager _browserManager;
     private readonly CommandLineOptions _options;
+    private readonly JsonSerializerOptions _serializerOptions;
     private readonly List<ToolDefinition> _tools = new();
     private readonly Dictionary<string, ToolDefinition> _toolMap = new(StringComparer.Ordinal);
 
     public ToolRegistry(CommandLineOptions options, BrowserManager browserManager)
     {
-        _browserManager = browserManager;
         _options = options;
-        BuildTools();
+        _serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        var providers = new object[]
+        {
+            new BrowserTools(browserManager)
+        };
+
+        foreach (var provider in providers)
+        {
+            foreach (var tool in AttributeToolDescriptor.Create(provider, _serializerOptions, options))
+            {
+                AddTool(tool);
+            }
+        }
     }
 
-    public IReadOnlyList<object> ListTools()
-    {
-        return _tools.Select(tool => tool.ToJson()).ToArray();
-    }
+    public IReadOnlyList<object> ListTools() => _tools.Select(tool => tool.ToJson()).ToArray();
 
     public async Task<McpResponse> CallToolAsync(string name, JsonElement? arguments)
     {
         if (!_toolMap.TryGetValue(name, out var tool))
             return ResponseBuilder.Error($"Tool \"{name}\" not found");
-        if (tool.Handler == null)
+        if (tool.Handler is null)
             return ResponseBuilder.Error($"Tool \"{name}\" is not implemented in this server.");
-        try
-        {
-            return await tool.Handler(arguments);
-        }
-        catch (Exception ex)
-        {
-            return ResponseBuilder.Error(ex.Message);
-        }
-    }
-
-    private void BuildTools()
-    {
-        AddTool(CreateNavigateTool());
-        AddTool(CreateNavigateBackTool());
-        AddTool(CreateClickTool());
-
-        AddTool(CreateStubTool("browser_console_messages", "Read console messages", "Inspect console output", ToolType.ReadOnly));
-        AddTool(CreateStubTool("browser_drag", "Drag element", "Drag an element on the page", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_evaluate", "Evaluate script", "Evaluate JavaScript in the page", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_file_upload", "Upload file", "Upload a file to an input", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_fill_form", "Fill form", "Fill a form field", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_handle_dialog", "Handle dialog", "Handle browser dialogs", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_hover", "Hover element", "Hover an element", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_select_option", "Select option", "Select option in a form control", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_type", "Type text", "Type into an element", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_close", "Close tab", "Close the current tab", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_install", "Install browser", "Install additional browser binaries", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_network_requests", "Inspect network", "Inspect network requests", ToolType.ReadOnly));
-        AddTool(CreateStubTool("browser_press_key", "Press key", "Press a key in the page", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_resize", "Resize page", "Resize the page viewport", ToolType.Destructive));
-        AddTool(CreateStubTool("browser_snapshot", "Take snapshot", "Capture a DOM snapshot", ToolType.ReadOnly));
-        AddTool(CreateStubTool("browser_tabs", "List tabs", "List open tabs", ToolType.ReadOnly));
-        AddTool(CreateStubTool("browser_take_screenshot", "Screenshot", "Capture a screenshot", ToolType.ReadOnly));
-        AddTool(CreateStubTool("browser_wait_for", "Wait for", "Wait for a condition", ToolType.Destructive));
-
-        if (_options.IncludeConnectTool)
-            AddTool(CreateStubTool("browser_connect", "Connect to browser", "Connect to an existing browser", ToolType.Destructive));
-
-        if (_options.Capabilities.Contains("pdf"))
-            AddTool(CreateStubTool("browser_pdf_save", "Save PDF", "Save the current page as PDF", ToolType.Destructive, capability: "pdf"));
-
-        if (_options.Capabilities.Contains("vision"))
-        {
-            AddTool(CreateStubTool("browser_mouse_move_xy", "Move mouse", "Move the mouse using coordinates", ToolType.Destructive, capability: "vision"));
-            AddTool(CreateStubTool("browser_mouse_click_xy", "Click mouse", "Click using page coordinates", ToolType.Destructive, capability: "vision"));
-            AddTool(CreateStubTool("browser_mouse_drag_xy", "Drag mouse", "Drag using page coordinates", ToolType.Destructive, capability: "vision"));
-        }
-
+        return await tool.Handler(arguments);
     }
 
     private void AddTool(ToolDefinition tool)
@@ -84,113 +56,6 @@ internal sealed class ToolRegistry
             return;
         _toolMap[tool.Name] = tool;
         _tools.Add(tool);
-    }
-
-    private ToolDefinition CreateNavigateTool()
-    {
-        var inputSchema = new
-        {
-            type = "object",
-            properties = new Dictionary<string, object>
-            {
-                ["url"] = new Dictionary<string, object>
-                {
-                    ["type"] = "string",
-                    ["description"] = "The URL to navigate to"
-                }
-            },
-            required = new[] { "url" }
-        };
-
-        return new ToolDefinition(
-            name: "browser_navigate",
-            title: "Navigate to a URL",
-            description: "Navigate to a URL",
-            type: ToolType.Destructive,
-            capability: "core",
-            inputSchema: inputSchema,
-            handler: async args =>
-            {
-                if (args is not { ValueKind: JsonValueKind.Object } element || !element.TryGetProperty("url", out var urlElement) || urlElement.ValueKind != JsonValueKind.String)
-                    return ResponseBuilder.Error("Missing \"url\" argument.");
-                var url = urlElement.GetString()!;
-                await _browserManager.NavigateAsync(url);
-                var snapshot = await _browserManager.CaptureSnapshotAsync();
-                var code = $"await page.goto('{ResponseBuilder.EscapeJavaScript(url)}');";
-                return ResponseBuilder.Success(code, snapshot);
-            }
-        );
-    }
-
-    private ToolDefinition CreateNavigateBackTool()
-    {
-        return CreateStubTool("browser_navigate_back", "Go back", "Navigate to the previous page", ToolType.Destructive);
-    }
-
-    private ToolDefinition CreateClickTool()
-    {
-        var inputSchema = new
-        {
-            type = "object",
-            properties = new Dictionary<string, object>
-            {
-                ["element"] = new Dictionary<string, object>
-                {
-                    ["type"] = "string",
-                    ["description"] = "The textual description of the element"
-                },
-                ["ref"] = new Dictionary<string, object>
-                {
-                    ["type"] = "string",
-                    ["description"] = "Element reference returned from page snapshot"
-                }
-            },
-            required = new[] { "element", "ref" }
-        };
-
-        return new ToolDefinition(
-            name: "browser_click",
-            title: "Click element",
-            description: "Click an element on the page",
-            type: ToolType.Destructive,
-            capability: "core",
-            inputSchema: inputSchema,
-            handler: async args =>
-            {
-                if (args is not { ValueKind: JsonValueKind.Object } element)
-                    return ResponseBuilder.Error("Invalid arguments for browser_click.");
-                if (!element.TryGetProperty("ref", out var refElement) || refElement.ValueKind != JsonValueKind.String)
-                    return ResponseBuilder.Error("Missing \"ref\" argument.");
-                var refId = refElement.GetString()!;
-                if (!_browserManager.TryGetElement(refId, out var info))
-                    return ResponseBuilder.Error($"Element reference '{refId}' was not found. Use browser_navigate to refresh the page state.");
-
-                await _browserManager.ClickAsync(info);
-                var snapshot = await _browserManager.CaptureSnapshotAsync();
-                var code = _browserManager.BuildClickSnippet(info);
-                return ResponseBuilder.Success(code, snapshot);
-            }
-        );
-    }
-
-    private static ToolDefinition CreateStubTool(string name, string title, string description, ToolType type, string capability = "core")
-    {
-        var inputSchema = new
-        {
-            type = "object",
-            properties = new Dictionary<string, object>(),
-            required = Array.Empty<string>()
-        };
-
-        return new ToolDefinition(
-            name,
-            title,
-            description,
-            type,
-            capability,
-            inputSchema,
-            handler: _ => Task.FromResult(ResponseBuilder.Error($"Tool \"{name}\" is not implemented in the C# server."))
-        );
     }
 }
 
@@ -202,7 +67,7 @@ internal enum ToolType
 
 internal sealed class ToolDefinition
 {
-    public ToolDefinition(string name, string title, string description, ToolType type, string capability, object inputSchema, Func<JsonElement?, Task<McpResponse>> handler)
+    public ToolDefinition(string name, string title, string description, ToolType type, string capability, object inputSchema, Func<JsonElement?, Task<McpResponse>>? handler)
     {
         Name = name;
         Title = title;
@@ -242,5 +107,217 @@ internal sealed class ToolDefinition
                 openWorldHint = true
             }
         };
+    }
+}
+
+internal static class AttributeToolDescriptor
+{
+    public static IEnumerable<ToolDefinition> Create(object provider, JsonSerializerOptions serializerOptions, CommandLineOptions options)
+    {
+        var methods = provider.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(method => method.GetCustomAttribute<McpServerToolAttribute>() is not null);
+
+        foreach (var method in methods)
+        {
+            var toolAttribute = method.GetCustomAttribute<McpServerToolAttribute>()!;
+            if (!ShouldIncludeTool(toolAttribute, options))
+                continue;
+
+            var typeAttribute = method.GetCustomAttribute<McpServerToolTypeAttribute>();
+            var description = method.GetCustomAttribute<DescriptionAttribute>()?.Description ?? toolAttribute.Title;
+            var inputSchema = BuildInputSchema(method);
+            var handler = BuildHandler(provider, method, serializerOptions);
+
+            yield return new ToolDefinition(
+                toolAttribute.Name,
+                toolAttribute.Title,
+                description,
+                typeAttribute?.Type ?? ToolType.Destructive,
+                toolAttribute.Capability,
+                inputSchema,
+                handler
+            );
+        }
+    }
+
+    private static bool ShouldIncludeTool(McpServerToolAttribute attribute, CommandLineOptions options)
+    {
+        if (attribute.RequiresConnectTool && !options.IncludeConnectTool)
+            return false;
+        if (!string.Equals(attribute.Capability, "core", StringComparison.OrdinalIgnoreCase) && !options.Capabilities.Contains(attribute.Capability))
+            return false;
+        return true;
+    }
+
+    private static object BuildInputSchema(MethodInfo method)
+    {
+        var parameters = method.GetParameters()
+            .Where(parameter => parameter.ParameterType != typeof(CancellationToken))
+            .ToArray();
+
+        if (parameters.Length == 0)
+        {
+            return new
+            {
+                type = "object",
+                properties = new Dictionary<string, object>(),
+                required = Array.Empty<string>()
+            };
+        }
+
+        if (parameters.Length > 1)
+        {
+            throw new InvalidOperationException($"Tool method '{method.Name}' can declare at most one argument parameter.");
+        }
+
+        var parameterType = parameters[0].ParameterType;
+        var properties = new Dictionary<string, object>();
+        var required = new List<string>();
+
+        foreach (var property in parameterType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (!property.CanRead)
+                continue;
+
+            var propertyName = ToCamelCase(property.Name);
+            var schema = new Dictionary<string, object>();
+            var (type, format) = ResolveSchemaType(property.PropertyType);
+            schema["type"] = type;
+            if (format is not null)
+                schema["format"] = format;
+            var description = property.GetCustomAttribute<DescriptionAttribute>()?.Description;
+            if (!string.IsNullOrWhiteSpace(description))
+                schema["description"] = description;
+
+            properties[propertyName] = schema;
+
+            if (IsRequired(property))
+                required.Add(propertyName);
+        }
+
+        return new
+        {
+            type = "object",
+            properties,
+            required = required.ToArray()
+        };
+    }
+
+    private static bool IsRequired(PropertyInfo property)
+    {
+        if (property.GetCustomAttribute<RequiredAttribute>() is not null)
+            return true;
+        var propertyType = property.PropertyType;
+        if (propertyType.IsValueType)
+            return Nullable.GetUnderlyingType(propertyType) is null;
+        return false;
+    }
+
+    private static (string Type, string? Format) ResolveSchemaType(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        if (underlying == typeof(string))
+            return ("string", null);
+        if (underlying == typeof(bool))
+            return ("boolean", null);
+        if (underlying == typeof(int) || underlying == typeof(long))
+            return ("integer", null);
+        if (underlying == typeof(float) || underlying == typeof(double) || underlying == typeof(decimal))
+            return ("number", null);
+        if (underlying.IsEnum)
+            return ("string", null);
+        throw new InvalidOperationException($"Unsupported property type '{underlying.Name}' for tool schema.");
+    }
+
+    private static Func<JsonElement?, Task<McpResponse>> BuildHandler(object provider, MethodInfo method, JsonSerializerOptions serializerOptions)
+    {
+        return async arguments =>
+        {
+            object?[] invocationArguments;
+            try
+            {
+                invocationArguments = CreateInvocationArguments(method, arguments, serializerOptions);
+            }
+            catch (ValidationException ex)
+            {
+                return ResponseBuilder.Error(ex.Message);
+            }
+            catch (JsonException)
+            {
+                return ResponseBuilder.Error($"Invalid arguments for tool '{method.Name}'.");
+            }
+            catch (InvalidOperationException ex)
+            {
+                return ResponseBuilder.Error(ex.Message);
+            }
+
+            try
+            {
+                var result = method.Invoke(provider, invocationArguments);
+                return await ConvertToResponseAsync(result);
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                return ResponseBuilder.Error(ex.InnerException.Message);
+            }
+        };
+    }
+
+    private static object?[] CreateInvocationArguments(MethodInfo method, JsonElement? arguments, JsonSerializerOptions serializerOptions)
+    {
+        var parameterInfos = method.GetParameters();
+        var values = new object?[parameterInfos.Length];
+
+        for (var index = 0; index < parameterInfos.Length; index++)
+        {
+            var parameter = parameterInfos[index];
+            if (parameter.ParameterType == typeof(CancellationToken))
+            {
+                values[index] = CancellationToken.None;
+                continue;
+            }
+
+            if (arguments is null || arguments.Value.ValueKind == JsonValueKind.Null)
+            {
+                throw new ValidationException("Tool arguments are required.");
+            }
+
+            var model = JsonSerializer.Deserialize(arguments.Value.GetRawText(), parameter.ParameterType, serializerOptions);
+            if (model is null)
+                throw new ValidationException("Tool arguments are required.");
+
+            ValidateModel(model);
+            values[index] = model;
+        }
+
+        return values;
+    }
+
+    private static void ValidateModel(object model)
+    {
+        var context = new ValidationContext(model);
+        Validator.ValidateObject(model, context, validateAllProperties: true);
+    }
+
+    private static async Task<McpResponse> ConvertToResponseAsync(object? result)
+    {
+        switch (result)
+        {
+            case McpResponse response:
+                return response;
+            case Task<McpResponse> task:
+                return await task.ConfigureAwait(false);
+            case ValueTask<McpResponse> valueTask:
+                return await valueTask.ConfigureAwait(false);
+            default:
+                throw new InvalidOperationException("Tool methods must return McpResponse or Task<McpResponse>.");
+        }
+    }
+
+    private static string ToCamelCase(string value)
+    {
+        if (string.IsNullOrEmpty(value) || char.IsLower(value, 0))
+            return value;
+        return char.ToLowerInvariant(value[0]) + value[1..];
     }
 }


### PR DESCRIPTION
## Summary
- replace the handwritten tool list with an attribute-driven registry that reflects decorated tool methods
- add a dedicated BrowserTools class that exposes Playwright actions through McpServerTool and McpServerToolType attributes
- extend the Playwright browser manager with selector-based clicking and document the available .NET tools in the README

## Testing
- `dotnet build` *(fails: dotnet executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6b9752f0832981cd802df18574a2