### PR TITLE
feat(dotnet): expand Playwright MCP tool coverage

### DIFF
--- a/dotnet/PlaywrightMcpServer/PlaywrightTools.cs
+++ b/dotnet/PlaywrightMcpServer/PlaywrightTools.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ChatUiTest.MCP.Playwright;
@@ -22,6 +25,11 @@ public sealed class PlaywrightTools
     private static IBrowserContext? _context;
     private static IPage? _page;
     private static bool _isChromium;
+    private static bool _tracingActive;
+
+    private static readonly List<ConsoleMessageEntry> ConsoleMessages = new();
+    private static readonly List<NetworkRequestEntry> NetworkRequests = new();
+    private static readonly Dictionary<string, NetworkRequestEntry> NetworkRequestMap = new();
 
     private static bool Headless =>
         (Environment.GetEnvironmentVariable("MCP_PLAYWRIGHT_HEADLESS") ?? "false")
@@ -38,6 +46,9 @@ public sealed class PlaywrightTools
     private static string ShotsDir =>
         Path.GetFullPath("./shots");
 
+    private static string TracesDir =>
+        Path.GetFullPath("./traces");
+
     private static string Serialize(object value) => JsonSerializer.Serialize(value, JsonOptions);
 
     private static async Task EnsureLaunchedAsync(CancellationToken cancellationToken)
@@ -47,12 +58,7 @@ public sealed class PlaywrightTools
         if (_page is not null)
             return;
 
-        lock (Gate)
-        {
-            Directory.CreateDirectory(DownloadsDir);
-            Directory.CreateDirectory(VideosDir);
-            Directory.CreateDirectory(ShotsDir);
-        }
+        EnsureDirectories();
 
         _playwright ??= await Microsoft.Playwright.Playwright.CreateAsync().ConfigureAwait(false);
 
@@ -83,7 +89,142 @@ public sealed class PlaywrightTools
 
         await _context.GrantAllPermissionsAsync().ConfigureAwait(false);
 
-        _page = await _context.NewPageAsync().ConfigureAwait(false);
+        var page = await _context.NewPageAsync().ConfigureAwait(false);
+        SetActivePage(page);
+    }
+
+    private static void SetActivePage(IPage page)
+    {
+        if (_page == page)
+            return;
+
+        if (_page is not null)
+            DetachPageEventHandlers(_page);
+
+        _page = page;
+
+        lock (ConsoleMessages)
+        {
+            ConsoleMessages.Clear();
+        }
+
+        lock (NetworkRequests)
+        {
+            NetworkRequests.Clear();
+            NetworkRequestMap.Clear();
+        }
+
+        AttachPageEventHandlers(page);
+    }
+
+    private static void AttachPageEventHandlers(IPage page)
+    {
+        page.Console += PageOnConsole;
+        page.Request += PageOnRequest;
+        page.Response += PageOnResponse;
+        page.RequestFailed += PageOnRequestFailed;
+    }
+
+    private static void DetachPageEventHandlers(IPage page)
+    {
+        page.Console -= PageOnConsole;
+        page.Request -= PageOnRequest;
+        page.Response -= PageOnResponse;
+        page.RequestFailed -= PageOnRequestFailed;
+    }
+
+    private static void PageOnConsole(object? sender, IConsoleMessage message)
+    {
+        var entry = new ConsoleMessageEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Type = message.Type,
+            Text = message.Text,
+            Args = message.Args.Select(arg => arg.ToString()).Where(arg => arg is not null).Cast<string>().ToArray()
+        };
+
+        lock (ConsoleMessages)
+        {
+            ConsoleMessages.Add(entry);
+            if (ConsoleMessages.Count > 200)
+                ConsoleMessages.RemoveAt(0);
+        }
+    }
+
+    private static void PageOnRequest(object? sender, IRequest request)
+    {
+        var entry = new NetworkRequestEntry
+        {
+            Timestamp = DateTimeOffset.UtcNow,
+            Method = request.Method,
+            Url = request.Url,
+            ResourceType = request.ResourceType,
+            Failure = null,
+            Status = null
+        };
+
+        lock (NetworkRequests)
+        {
+            NetworkRequests.Add(entry);
+            NetworkRequestMap[request.Guid] = entry;
+            if (NetworkRequests.Count > 500)
+            {
+                var first = NetworkRequests.First();
+                NetworkRequests.RemoveAt(0);
+                var keyToRemove = NetworkRequestMap.FirstOrDefault(kvp => kvp.Value == first).Key;
+                if (keyToRemove is not null)
+                    NetworkRequestMap.Remove(keyToRemove);
+            }
+        }
+    }
+
+    private static void PageOnResponse(object? sender, IResponse response)
+    {
+        lock (NetworkRequests)
+        {
+            if (NetworkRequestMap.TryGetValue(response.Request.Guid, out var entry))
+            {
+                entry.Status = response.Status;
+            }
+        }
+    }
+
+    private static void PageOnRequestFailed(object? sender, IRequest request)
+    {
+        lock (NetworkRequests)
+        {
+            if (NetworkRequestMap.TryGetValue(request.Guid, out var entry))
+            {
+                entry.Failure = request.Failure;
+            }
+        }
+    }
+
+    private static ConsoleMessageEntry[] SnapshotConsoleMessages()
+    {
+        lock (ConsoleMessages)
+        {
+            return ConsoleMessages.ToArray();
+        }
+    }
+
+    private static NetworkRequestEntry[] SnapshotNetworkRequests()
+    {
+        lock (NetworkRequests)
+        {
+            return NetworkRequests.Select(r => r.Clone()).ToArray();
+        }
+    }
+
+    private static void EnsureDirectories()
+    {
+        lock (Gate)
+        {
+            Directory.CreateDirectory(DownloadsDir);
+            Directory.CreateDirectory(VideosDir);
+            Directory.CreateDirectory(ShotsDir);
+            Directory.CreateDirectory(TracesDir);
+        }
     }
 
     [McpServerTool]
@@ -92,6 +233,7 @@ public sealed class PlaywrightTools
     {
         if (_page is not null)
         {
+            DetachPageEventHandlers(_page);
             try { await _page.CloseAsync().ConfigureAwait(false); }
             catch { }
             _page = null;
@@ -118,6 +260,7 @@ public sealed class PlaywrightTools
         }
 
         _isChromium = false;
+        _tracingActive = false;
         return Serialize(new { closed = true });
     }
 
@@ -154,6 +297,27 @@ public sealed class PlaywrightTools
     }
 
     [McpServerTool]
+    [Description("Go back in browser history if possible.")]
+    public static async Task<string> GoBackAsync(
+        [Description("Timeout ms (default 15000)")] int? timeoutMs = 15000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        var response = await _page!.GoBackAsync(new PageGoBackOptions
+        {
+            Timeout = timeoutMs,
+            WaitUntil = WaitUntilState.Load
+        }).ConfigureAwait(false);
+
+        return Serialize(new
+        {
+            url = _page.Url,
+            status = response?.Status,
+            ok = response?.Ok
+        });
+    }
+
+    [McpServerTool]
     [Description("Click an element by CSS/XPath/text selector.")]
     public static async Task<string> ClickAsync(
         [Description("Selector (CSS default; prefix with xpath= for XPath, text= for text)")] string selector,
@@ -166,6 +330,37 @@ public sealed class PlaywrightTools
             Timeout = timeoutMs
         }).ConfigureAwait(false);
         return Serialize(new { clicked = selector });
+    }
+
+    [McpServerTool]
+    [Description("Hover over an element by selector.")]
+    public static async Task<string> HoverAsync(
+        [Description("Selector")] string selector,
+        [Description("Timeout ms (default 10000)")] int? timeoutMs = 10000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.HoverAsync(selector, new PageHoverOptions
+        {
+            Timeout = timeoutMs
+        }).ConfigureAwait(false);
+        return Serialize(new { hovered = selector });
+    }
+
+    [McpServerTool]
+    [Description("Drag an element onto another selector.")]
+    public static async Task<string> DragAndDropAsync(
+        [Description("Source selector")] string sourceSelector,
+        [Description("Target selector")] string targetSelector,
+        [Description("Timeout ms (default 15000)")] int? timeoutMs = 15000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.DragAndDropAsync(sourceSelector, targetSelector, new PageDragAndDropOptions
+        {
+            Timeout = timeoutMs
+        }).ConfigureAwait(false);
+        return Serialize(new { dragged = sourceSelector, droppedOn = targetSelector });
     }
 
     [McpServerTool]
@@ -185,6 +380,31 @@ public sealed class PlaywrightTools
     }
 
     [McpServerTool]
+    [Description("Type text into an element, optionally pressing Enter.")]
+    public static async Task<string> TypeAsync(
+        [Description("Selector")] string selector,
+        [Description("Text to type")] string text,
+        [Description("Submit (press Enter) after typing")] bool submit = false,
+        [Description("Delay between keystrokes in ms")] int? delayMs = null,
+        [Description("Timeout ms (default 10000)")] int? timeoutMs = 10000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        var locator = _page!.Locator(selector).First;
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeoutMs }).ConfigureAwait(false);
+        await locator.TypeAsync(text ?? string.Empty, new LocatorTypeOptions
+        {
+            Delay = delayMs,
+            Timeout = timeoutMs
+        }).ConfigureAwait(false);
+
+        if (submit)
+            await locator.PressAsync("Enter").ConfigureAwait(false);
+
+        return Serialize(new { typed = selector, length = text?.Length ?? 0, submit });
+    }
+
+    [McpServerTool]
     [Description("Get innerText from the first matched element.")]
     public static async Task<string> InnerTextAsync(
         [Description("Selector")] string selector,
@@ -199,6 +419,22 @@ public sealed class PlaywrightTools
         }).ConfigureAwait(false);
         var text = await locator.InnerTextAsync().ConfigureAwait(false);
         return Serialize(new { selector, text });
+    }
+
+    [McpServerTool]
+    [Description("Press a single keyboard key on the active page.")]
+    public static async Task<string> PressKeyAsync(
+        [Description("Key, e.g. Enter or Control+S")] string key,
+        [Description("Delay between keydown and keyup in ms")] int? delayMs = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.Keyboard.PressAsync(key, new KeyboardPressOptions
+        {
+            Delay = delayMs
+        }).ConfigureAwait(false);
+
+        return Serialize(new { pressed = key, delayMs });
     }
 
     [McpServerTool]
@@ -248,6 +484,88 @@ public sealed class PlaywrightTools
     }
 
     [McpServerTool]
+    [Description("Select one or more option values in a select element.")]
+    public static async Task<string> SelectOptionAsync(
+        [Description("Selector for the <select> element")] string selector,
+        [Description("Values to select")] string[] values,
+        [Description("Timeout ms (default 10000)")] int? timeoutMs = 10000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        if (values is null || values.Length == 0)
+            throw new ArgumentException("At least one value must be provided.", nameof(values));
+
+        var locator = _page!.Locator(selector).First;
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeoutMs }).ConfigureAwait(false);
+        var selected = await locator.SelectOptionAsync(values.Select(v => new SelectOptionValue { Value = v }).ToArray(), new LocatorSelectOptionOptions
+        {
+            Timeout = timeoutMs
+        }).ConfigureAwait(false);
+
+        return Serialize(new { selector, selected });
+    }
+
+    [McpServerTool]
+    [Description("Upload local files to an <input type=\"file\"> element.")]
+    public static async Task<string> UploadFilesAsync(
+        [Description("Selector for file input")] string selector,
+        [Description("Absolute or relative file paths")] string[] paths,
+        [Description("Timeout ms (default 10000)")] int? timeoutMs = 10000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        if (paths is null || paths.Length == 0)
+            throw new ArgumentException("At least one path must be provided.", nameof(paths));
+
+        var locator = _page!.Locator(selector).First;
+        await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeoutMs }).ConfigureAwait(false);
+
+        var absolutePaths = paths.Select(path => Path.GetFullPath(path)).ToArray();
+        foreach (var filePath in absolutePaths)
+        {
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException($"File not found: {filePath}", filePath);
+        }
+        await locator.SetInputFilesAsync(absolutePaths);
+
+        return Serialize(new { selector, count = absolutePaths.Length });
+    }
+
+    [McpServerTool]
+    [Description("Fill multiple form fields by selector.")]
+    public static async Task<string> FillFormAsync(
+        [Description("Fields to fill")] FormField[] fields,
+        [Description("Timeout ms per field (default 10000)")] int? timeoutMs = 10000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        if (fields is null || fields.Length == 0)
+            throw new ArgumentException("At least one field must be provided.", nameof(fields));
+
+        var results = new List<object>();
+
+        foreach (var field in fields)
+        {
+            var locator = _page!.Locator(field.Selector).First;
+            await locator.WaitForAsync(new LocatorWaitForOptions { Timeout = timeoutMs }).ConfigureAwait(false);
+
+            if (string.Equals(field.Action, "select", StringComparison.OrdinalIgnoreCase))
+            {
+                var optionValues = (field.Values ?? Array.Empty<string>()).Select(v => new SelectOptionValue { Value = v }).ToArray();
+                var selected = await locator.SelectOptionAsync(optionValues, new LocatorSelectOptionOptions { Timeout = timeoutMs }).ConfigureAwait(false);
+                results.Add(new { field.Selector, action = "select", selected });
+            }
+            else
+            {
+                await locator.FillAsync(field.Value ?? string.Empty, new LocatorFillOptions { Timeout = timeoutMs }).ConfigureAwait(false);
+                results.Add(new { field.Selector, action = "fill", length = field.Value?.Length ?? 0 });
+            }
+        }
+
+        return Serialize(new { count = results.Count, results });
+    }
+
+    [McpServerTool]
     [Description("Export current page as PDF (Chromium only).")]
     public static async Task<string> PdfAsync(
         [Description("Output path (*.pdf). If relative, saved under ./shots")] string outputPath,
@@ -283,6 +601,69 @@ public sealed class PlaywrightTools
     }
 
     [McpServerTool]
+    [Description("Handle the next dialog by accepting or dismissing it.")]
+    public static async Task<string> HandleDialogAsync(
+        [Description("Accept dialog (true) or dismiss (false)")] bool accept = true,
+        [Description("Prompt text when accepting")] string? promptText = null,
+        [Description("Timeout ms (default 15000)")] int? timeoutMs = 15000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+
+        var page = _page!;
+        var tcs = new TaskCompletionSource<DialogResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (timeoutMs is > 0)
+            cts.CancelAfter(TimeSpan.FromMilliseconds(timeoutMs.Value));
+
+        void Handler(object? sender, IDialog dialog)
+        {
+            page.Dialog -= Handler;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    if (accept)
+                        await dialog.AcceptAsync(promptText).ConfigureAwait(false);
+                    else
+                        await dialog.DismissAsync().ConfigureAwait(false);
+
+                    tcs.TrySetResult(new DialogResult(dialog.Type, dialog.Message, dialog.DefaultValue));
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            });
+        }
+
+        page.Dialog += Handler;
+
+        using var registration = cts.Token.Register(() => tcs.TrySetCanceled(cts.Token));
+
+        try
+        {
+            var result = await tcs.Task.ConfigureAwait(false);
+            return Serialize(new
+            {
+                handled = true,
+                accepted = accept,
+                result.Type,
+                result.Message,
+                result.DefaultValue
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            return Serialize(new { handled = false, timeout = true });
+        }
+        finally
+        {
+            page.Dialog -= Handler;
+        }
+    }
+
+    [McpServerTool]
     [Description("Wait for selector to be attached/visible/hidden/detached.")]
     public static async Task<string> WaitForSelectorAsync(
         [Description("Selector")] string selector,
@@ -310,6 +691,52 @@ public sealed class PlaywrightTools
     }
 
     [McpServerTool]
+    [Description("Wait for text to appear/disappear or for a specific time.")]
+    public static async Task<string> WaitForAsync(
+        [Description("Text to appear")] string? text = null,
+        [Description("Text to disappear")] string? textGone = null,
+        [Description("Wait this many ms regardless of text")] int? timeMs = null,
+        [Description("Timeout ms for text waits (default 15000)")] int? timeoutMs = 15000,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        var page = _page!;
+        bool? appeared = null;
+        bool? disappeared = null;
+
+        if (timeMs is > 0)
+            await Task.Delay(timeMs.Value, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            await page.WaitForFunctionAsync(
+                "(expected) => document.body && document.body.innerText.includes(expected)",
+                text,
+                new PageWaitForFunctionOptions { Timeout = timeoutMs }
+            ).ConfigureAwait(false);
+            appeared = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(textGone))
+        {
+            await page.WaitForFunctionAsync(
+                "(expected) => !document.body || !document.body.innerText.includes(expected)",
+                textGone,
+                new PageWaitForFunctionOptions { Timeout = timeoutMs }
+            ).ConfigureAwait(false);
+            disappeared = true;
+        }
+
+        return Serialize(new
+        {
+            waited = true,
+            appeared = appeared == true ? text : null,
+            disappeared = disappeared == true ? textGone : null,
+            timeMs
+        });
+    }
+
+    [McpServerTool]
     [Description("Evaluate JavaScript in page and return JSON-serializable result.")]
     public static async Task<string> EvalAsync(
         [Description("JS expression: must return JSON-serializable value")] string jsExpression,
@@ -326,5 +753,277 @@ public sealed class PlaywrightTools
     {
         await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
         return Serialize(new { url = _page!.Url });
+    }
+
+    [McpServerTool]
+    [Description("Get captured console messages since the current page was opened/switch.")]
+    public static async Task<string> ConsoleMessagesAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        var messages = SnapshotConsoleMessages();
+        return Serialize(new { messages });
+    }
+
+    [McpServerTool]
+    [Description("List captured network requests since the current page was opened/switch.")]
+    public static async Task<string> NetworkRequestsAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        var requests = SnapshotNetworkRequests();
+        return Serialize(new { requests });
+    }
+
+    [McpServerTool]
+    [Description("Resize browser viewport.")]
+    public static async Task<string> ResizeAsync(
+        [Description("Viewport width")] int width,
+        [Description("Viewport height")] int height,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.SetViewportSizeAsync(new ViewportSize { Width = width, Height = height }).ConfigureAwait(false);
+        return Serialize(new { width, height });
+    }
+
+    [McpServerTool]
+    [Description("Capture an accessibility snapshot of the page.")]
+    public static async Task<string> SnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        var snapshot = await _page!.Accessibility.SnapshotAsync().ConfigureAwait(false);
+        return Serialize(new { snapshot });
+    }
+
+    [McpServerTool]
+    [Description("Manage tabs: list, create, close or switch.")]
+    public static async Task<string> TabsAsync(
+        [Description("Action: list|new|close|switch")] string action,
+        [Description("Zero-based tab index (for close/switch)")] int? index = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_context is null)
+            throw new InvalidOperationException("Browser context not initialized.");
+
+        switch (action.ToLowerInvariant())
+        {
+            case "list":
+                var list = _context.Pages.Select((p, i) => new
+                {
+                    index = i,
+                    url = p.Url,
+                    isClosed = p.IsClosed,
+                    isActive = p == _page
+                }).ToArray();
+                return Serialize(new { tabs = list });
+
+            case "new":
+                var newPage = await _context.NewPageAsync().ConfigureAwait(false);
+                SetActivePage(newPage);
+                return Serialize(new { created = _context.Pages.Count, activeIndex = GetPageIndex(newPage) });
+
+            case "switch":
+                if (index is null)
+                    throw new ArgumentException("Index required for switch action.", nameof(index));
+                if (index < 0 || index >= _context.Pages.Count)
+                    throw new ArgumentOutOfRangeException(nameof(index), index, "Tab index out of range.");
+                var switchPage = _context.Pages[index.Value];
+                if (switchPage.IsClosed)
+                    throw new InvalidOperationException("Cannot switch to a closed tab.");
+                SetActivePage(switchPage);
+                return Serialize(new { activeIndex = index, url = switchPage.Url });
+
+            case "close":
+                if (index is null)
+                    throw new ArgumentException("Index required for close action.", nameof(index));
+                if (index < 0 || index >= _context.Pages.Count)
+                    throw new ArgumentOutOfRangeException(nameof(index), index, "Tab index out of range.");
+                var target = _context.Pages[index.Value];
+                var wasActive = target == _page;
+                await target.CloseAsync().ConfigureAwait(false);
+
+                var remaining = _context.Pages.FirstOrDefault(p => !p.IsClosed);
+                if (remaining is null)
+                {
+                    var replacement = await _context.NewPageAsync().ConfigureAwait(false);
+                    SetActivePage(replacement);
+                    return Serialize(new { closed = index, activeIndex = GetPageIndex(replacement) });
+                }
+
+                if (wasActive)
+                    SetActivePage(remaining);
+
+                return Serialize(new { closed = index, activeIndex = GetPageIndex(_page!) });
+
+            default:
+                throw new ArgumentException($"Unsupported action '{action}'.", nameof(action));
+        }
+    }
+
+    [McpServerTool]
+    [Description("Install Playwright browsers using bundled CLI.")]
+    public static async Task<string> InstallAsync(
+        [Description("Optional browser name, e.g. chromium")] string? browser = null,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new List<string> { "install" };
+        if (!string.IsNullOrWhiteSpace(browser))
+            args.Add(browser);
+
+        var exitCode = await Microsoft.Playwright.Program.Main(args.ToArray()).ConfigureAwait(false);
+        return Serialize(new { success = exitCode == 0, exitCode, browser });
+    }
+
+    [McpServerTool]
+    [Description("Move mouse to coordinates relative to page viewport.")]
+    public static async Task<string> MouseMoveAsync(
+        [Description("X coordinate")] double x,
+        [Description("Y coordinate")] double y,
+        [Description("Number of move steps")] int? steps = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.Mouse.MoveAsync(x, y, new MouseMoveOptions { Steps = steps }).ConfigureAwait(false);
+        return Serialize(new { x, y, steps });
+    }
+
+    [McpServerTool]
+    [Description("Click mouse at coordinates relative to page viewport.")]
+    public static async Task<string> MouseClickAsync(
+        [Description("X coordinate")] double x,
+        [Description("Y coordinate")] double y,
+        [Description("Button: left|middle|right")] string? button = "left",
+        [Description("Number of clicks")] int clickCount = 1,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.Mouse.ClickAsync(x, y, new MouseClickOptions
+        {
+            Button = button switch
+            {
+                "middle" => MouseButton.Middle,
+                "right" => MouseButton.Right,
+                _ => MouseButton.Left
+            },
+            ClickCount = clickCount
+        }).ConfigureAwait(false);
+        return Serialize(new { x, y, button, clickCount });
+    }
+
+    [McpServerTool]
+    [Description("Drag mouse between coordinates relative to viewport.")]
+    public static async Task<string> MouseDragAsync(
+        [Description("Start X")] double startX,
+        [Description("Start Y")] double startY,
+        [Description("End X")] double endX,
+        [Description("End Y")] double endY,
+        [Description("Steps for the move")] int? steps = 25,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        await _page!.Mouse.MoveAsync(startX, startY).ConfigureAwait(false);
+        await _page.Mouse.DownAsync().ConfigureAwait(false);
+        await _page.Mouse.MoveAsync(endX, endY, new MouseMoveOptions { Steps = steps }).ConfigureAwait(false);
+        await _page.Mouse.UpAsync().ConfigureAwait(false);
+        return Serialize(new { startX, startY, endX, endY, steps });
+    }
+
+    [McpServerTool]
+    [Description("Start Playwright tracing (snapshots, screenshots, sources).")]
+    public static async Task<string> StartTracingAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        if (_context is null)
+            throw new InvalidOperationException("Browser context not initialized.");
+
+        if (_tracingActive)
+            return Serialize(new { tracing = true, alreadyStarted = true });
+
+        await _context.Tracing.StartAsync(new TracingStartOptions
+        {
+            Screenshots = true,
+            Snapshots = true,
+            Sources = true
+        }).ConfigureAwait(false);
+
+        _tracingActive = true;
+        return Serialize(new { tracing = true });
+    }
+
+    [McpServerTool]
+    [Description("Stop tracing and save to a .zip file.")]
+    public static async Task<string> StopTracingAsync(
+        [Description("Output path for trace .zip (default ./traces/trace-<timestamp>.zip")] string? outputPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
+        if (_context is null)
+            throw new InvalidOperationException("Browser context not initialized.");
+
+        if (!_tracingActive)
+            return Serialize(new { tracing = false, alreadyStopped = true });
+
+        EnsureDirectories();
+        var path = string.IsNullOrWhiteSpace(outputPath)
+            ? Path.Combine(TracesDir, $"trace-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}.zip")
+            : Path.GetFullPath(outputPath);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        await _context.Tracing.StopAsync(new TracingStopOptions
+        {
+            Path = path
+        }).ConfigureAwait(false);
+
+        _tracingActive = false;
+        return Serialize(new { tracing = false, path });
+    }
+
+    private sealed record DialogResult(string Type, string Message, string? DefaultValue);
+
+    public sealed record FormField(
+        [property: JsonPropertyName("selector")] string Selector,
+        [property: JsonPropertyName("value")] string? Value,
+        [property: JsonPropertyName("action")] string? Action,
+        [property: JsonPropertyName("values")] string[]? Values);
+
+    public sealed record ConsoleMessageEntry
+    {
+        [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
+        [JsonPropertyName("type")] public string Type { get; init; } = string.Empty;
+        [JsonPropertyName("text")] public string Text { get; init; } = string.Empty;
+        [JsonPropertyName("args")][AllowNull] public string[]? Args { get; init; }
+    }
+
+    public sealed class NetworkRequestEntry
+    {
+        [JsonPropertyName("timestamp")] public DateTimeOffset Timestamp { get; init; }
+        [JsonPropertyName("method")] public string Method { get; init; } = string.Empty;
+        [JsonPropertyName("url")] public string Url { get; init; } = string.Empty;
+        [JsonPropertyName("resourceType")][AllowNull] public string? ResourceType { get; init; }
+        [JsonPropertyName("status")][AllowNull] public int? Status { get; set; }
+        [JsonPropertyName("failure")][AllowNull] public string? Failure { get; set; }
+
+        public NetworkRequestEntry Clone() => new()
+        {
+            Timestamp = Timestamp,
+            Method = Method,
+            Url = Url,
+            ResourceType = ResourceType,
+            Status = Status,
+            Failure = Failure
+        };
+    }
+
+    private static int GetPageIndex(IPage page)
+    {
+        if (_context is null)
+            return -1;
+
+        var match = _context.Pages
+            .Select((p, idx) => new { Page = p, Index = idx })
+            .FirstOrDefault(tuple => tuple.Page == page);
+        return match?.Index ?? -1;
     }
 }


### PR DESCRIPTION
## Summary
- add shared page lifecycle bookkeeping so the .NET server can track console and network events across page switches
- implement the missing Playwright automation tools (navigation, interaction, waiting, logging, tab, mouse, pdf/tracing) to mirror the TypeScript MCP feature set
- expose browser installation and tracing helpers while wiring new tool responses through strongly typed DTOs

## Testing
- `dotnet build dotnet/PlaywrightMcpServer/PlaywrightMcpServer.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dcce5ce8c8832995497c025d4ae43c

## Sourcery 总结

扩展 .NET Playwright MCP 服务器，通过添加全面的自动化工具、事件跟踪、安装和追踪支持以及类型化的工具响应，使其完全镜像 TypeScript MCP 的功能集。

新功能：
- 实现缺失的导航（GoBack, Tabs）、交互（Hover, DragAndDrop, Type, PressKey）和表单控制（FillForm, SelectOption, UploadFiles）自动化工具
- 添加键盘和鼠标控制工具、可访问性快照、PDF 导出和浏览器安装命令
- 暴露启动/停止追踪和捕获辅助工具，以及 consoleMessages 和 networkRequests 日志工具

增强功能：
- 引入共享页面生命周期记账，以跟踪跨页面切换的控制台和网络事件
- 在单个 EnsureDirectories 方法中管理追踪、下载、视频和截图目录
- 通过强类型 DTO（FormField, ConsoleMessageEntry, NetworkRequestEntry, DialogResult）返回工具结果

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand the .NET Playwright MCP server to fully mirror the TypeScript MCP feature set by adding comprehensive automation tools, event tracking, install and tracing support, and typed tool responses

New Features:
- Implement missing automation tools for navigation (GoBack, Tabs), interaction (Hover, DragAndDrop, Type, PressKey), and form controls (FillForm, SelectOption, UploadFiles)
- Add keyboard and mouse control tools, accessibility snapshot, PDF export, and browser install commands
- Expose start/stop tracing and capture helpers alongside consoleMessages and networkRequests logging tools

Enhancements:
- Introduce shared page lifecycle bookkeeping to track console and network events across page switches
- Manage trace, download, video, and screenshot directories in a single EnsureDirectories method
- Return tool results via strongly typed DTOs (FormField, ConsoleMessageEntry, NetworkRequestEntry, DialogResult)

</details>