### PR TITLE
Fix mouse helper parameter types

### DIFF
--- a/dotnet/PlaywrightMcpServer/PlaywrightTools.cs
+++ b/dotnet/PlaywrightMcpServer/PlaywrightTools.cs
@@ -884,7 +884,7 @@ public sealed class PlaywrightTools
         CancellationToken cancellationToken = default)
     {
         await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
-        await _page!.Mouse.MoveAsync(x, y, new MouseMoveOptions { Steps = steps }).ConfigureAwait(false);
+        await _page!.Mouse.MoveAsync((float)x, (float)y, new MouseMoveOptions { Steps = steps }).ConfigureAwait(false);
         return Serialize(new { x, y, steps });
     }
 
@@ -898,7 +898,7 @@ public sealed class PlaywrightTools
         CancellationToken cancellationToken = default)
     {
         await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
-        await _page!.Mouse.ClickAsync(x, y, new MouseClickOptions
+        await _page!.Mouse.ClickAsync((float)x, (float)y, new MouseClickOptions
         {
             Button = button switch
             {
@@ -922,9 +922,9 @@ public sealed class PlaywrightTools
         CancellationToken cancellationToken = default)
     {
         await EnsureLaunchedAsync(cancellationToken).ConfigureAwait(false);
-        await _page!.Mouse.MoveAsync(startX, startY).ConfigureAwait(false);
+        await _page!.Mouse.MoveAsync((float)startX, (float)startY).ConfigureAwait(false);
         await _page.Mouse.DownAsync().ConfigureAwait(false);
-        await _page.Mouse.MoveAsync(endX, endY, new MouseMoveOptions { Steps = steps }).ConfigureAwait(false);
+        await _page.Mouse.MoveAsync((float)endX, (float)endY, new MouseMoveOptions { Steps = steps }).ConfigureAwait(false);
         await _page.Mouse.UpAsync().ConfigureAwait(false);
         return Serialize(new { startX, startY, endX, endY, steps });
     }


### PR DESCRIPTION
## Summary
- cast mouse coordinate arguments to floats when calling Playwright mouse helpers to match API expectations

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd348f7d4c8329b2b0ef5ee29ae4c3

## Sourcery 总结

错误修复：
- 在鼠标移动、点击和拖动辅助函数中，将鼠标坐标参数转换为浮点数，以符合 Playwright API 的预期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Cast mouse coordinate arguments to float in mouse move, click, and drag helpers to align with Playwright API expectations

</details>